### PR TITLE
Fix tests for cache backtrace enabled

### DIFF
--- a/src/bin/has_backtrace.rs
+++ b/src/bin/has_backtrace.rs
@@ -1,0 +1,17 @@
+//! Exits with exit code 0 if backtraces are disabled and 1 if they are enabled.
+//! Used by tests to make sure backtraces are available when they should be.
+
+#[macro_use]
+extern crate error_chain;
+
+error_chain! {
+    errors {
+        MyError
+    }
+}
+
+fn main() {
+    let err = Error::from(ErrorKind::MyError);
+    let has_backtrace = err.backtrace().is_some();
+    ::std::process::exit(has_backtrace as i32);
+}


### PR DESCRIPTION
Fixing the failing test in https://github.com/rust-lang-nursery/error-chain/pull/210